### PR TITLE
Added null check to prevent error on scene load

### DIFF
--- a/TarsierSpaceTechnology/TarsierSpaceTech/TSTProgressTracker.cs
+++ b/TarsierSpaceTechnology/TarsierSpaceTech/TSTProgressTracker.cs
@@ -165,7 +165,8 @@ namespace TarsierSpaceTech
             Utils.print("Getting Telescope Galaxy Status");
             foreach (TSTGalaxy g in TSTGalaxies.Galaxies)
             {
-                if (telescopeNode.HasValue(g.name))
+                //Added null check as it was throwing errors in my career games and maybe causing issues with other scenario modules
+                if (telescopeNode!=null &&  telescopeNode.HasValue(g.name)) 
                     TelescopeData[g.name] = telescopeNode != null ? (telescopeNode.GetValue(g.name) == "true") : false;
                 else
                     TelescopeData[g.name] = false;

--- a/TarsierSpaceTechnology/TarsierSpaceTech/TSTProgressTracker.cs
+++ b/TarsierSpaceTechnology/TarsierSpaceTech/TSTProgressTracker.cs
@@ -27,7 +27,7 @@ namespace TarsierSpaceTech
             Instance = this;
         }
 
-        int i = 0;
+        //int i = 0;
 
         public void Update()
         {
@@ -163,13 +163,17 @@ namespace TarsierSpaceTech
                 TelescopeData[b.name] = telescopeNode != null ? (telescopeNode.GetValue(b.name) == "true") : false;
 
             Utils.print("Getting Telescope Galaxy Status");
-            foreach (TSTGalaxy g in TSTGalaxies.Galaxies)
-            {
-                //Added null check as it was throwing errors in my career games and maybe causing issues with other scenario modules
-                if (telescopeNode!=null &&  telescopeNode.HasValue(g.name)) 
-                    TelescopeData[g.name] = telescopeNode != null ? (telescopeNode.GetValue(g.name) == "true") : false;
-                else
-                    TelescopeData[g.name] = false;
+            try {
+                foreach (TSTGalaxy g in TSTGalaxies.Galaxies)
+                {
+                    //Added null check as it was throwing errors in my career games and maybe causing issues with other scenario modules
+                    if (telescopeNode != null && telescopeNode.HasValue(g.name))
+                        TelescopeData[g.name] = telescopeNode != null ? (telescopeNode.GetValue(g.name) == "true") : false;
+                    else
+                        TelescopeData[g.name] = false;
+                }
+            } catch (Exception ex) {
+                Utils.print("Getting Telescope Galaxy Failed unexpectedly. Ex: " + ex.Message);
             }
 
             Utils.print("Getting ChemCam Celestial Body Status");

--- a/TarsierSpaceTechnology/TarsierSpaceTech/TSTSpaceTelescope.cs
+++ b/TarsierSpaceTechnology/TarsierSpaceTech/TSTSpaceTelescope.cs
@@ -276,7 +276,7 @@ namespace TarsierSpaceTech
                             Contracts.ContractSystem.Instance.GetCurrentActiveContracts<TSTTelescopeContract>()
                                 .Any(t => t.target.name == g.name)
                         )
-                ) ? GUILayout.Button(g.theName + " (contract)") : (filterContractTargets ? false : GUILayout.Button(g.theName)));
+                ) ? GUILayout.Button(g.theName) : (filterContractTargets ? false : GUILayout.Button(g.theName)));
 
             Utils.print(String.Format(" - TargettingWindow - newTarget = {0}", newTarget));
 

--- a/TarsierSpaceTechnology/TarsierSpaceTech/TSTSpaceTelescope.cs
+++ b/TarsierSpaceTechnology/TarsierSpaceTech/TSTSpaceTelescope.cs
@@ -262,14 +262,17 @@ namespace TarsierSpaceTech
         private void TargettingWindow(int windowID)
         {
             GUILayout.BeginVertical();
+
             int newTarget = TSTGalaxies.Galaxies.
                 FindIndex(
                     g => (
-                        TSTProgressTracker.HasTelescopeCompleted(g) |
-                        Contracts.ContractSystem.Instance.GetCurrentActiveContracts<TSTTelescopeContract>()
-                            .Any(t => t.target.name == g.name
-                    )
+                        TSTProgressTracker.HasTelescopeCompleted(g) ||
+                        (Contracts.ContractSystem.Instance &&
+                            Contracts.ContractSystem.Instance.GetCurrentActiveContracts<TSTTelescopeContract>()
+                                .Any(t => t.target.name == g.name)
+                        )
                 ) ? GUILayout.Button(g.theName) : false);
+
             if (newTarget != -1 && newTarget != selectedTargetIndex)
             {
                 vessel.targetObject = null;
@@ -280,6 +283,7 @@ namespace TarsierSpaceTech
                 Utils.print("Targetting: " + newTarget.ToString() + " " + galaxyTarget.name);
                 ScreenMessages.PostScreenMessage("Target: "+galaxyTarget.theName, 3f, ScreenMessageStyle.UPPER_CENTER);
             }
+
             GUILayout.Space(10);
             showTargetsWindow = !GUILayout.Button("Hide");
             GUILayout.EndVertical();

--- a/TarsierSpaceTechnology/TarsierSpaceTech/TSTSpaceTelescope.cs
+++ b/TarsierSpaceTechnology/TarsierSpaceTech/TSTSpaceTelescope.cs
@@ -30,6 +30,7 @@ namespace TarsierSpaceTech
         private WindowSate windowState = WindowSate.Small;
         private Rect targetWindowPos = new Rect(512, 128, 0, 0);
         private bool showTargetsWindow = false;
+        private bool filterContractTargets = false;
         int selectedTargetIndex = -1;
 
         [KSPField(guiActive = false, guiName = "maxZoom", isPersistant = true)]
@@ -263,6 +264,10 @@ namespace TarsierSpaceTech
         {
             GUILayout.BeginVertical();
 
+            filterContractTargets = GUILayout.Toggle(filterContractTargets, "Show only contract targets");
+
+            Utils.print(String.Format(" - TargettingWindow - TSTGalaxies.Galaxies.Count = {0}", TSTGalaxies.Galaxies.Count));
+
             int newTarget = TSTGalaxies.Galaxies.
                 FindIndex(
                     g => (
@@ -271,7 +276,9 @@ namespace TarsierSpaceTech
                             Contracts.ContractSystem.Instance.GetCurrentActiveContracts<TSTTelescopeContract>()
                                 .Any(t => t.target.name == g.name)
                         )
-                ) ? GUILayout.Button(g.theName) : false);
+                ) ? GUILayout.Button(g.theName + " (contract)") : (filterContractTargets ? false : GUILayout.Button(g.theName)));
+
+            Utils.print(String.Format(" - TargettingWindow - newTarget = {0}", newTarget));
 
             if (newTarget != -1 && newTarget != selectedTargetIndex)
             {

--- a/TarsierSpaceTechnology/TarsierSpaceTech/TarsierSpaceTech.csproj
+++ b/TarsierSpaceTechnology/TarsierSpaceTech/TarsierSpaceTech.csproj
@@ -34,10 +34,6 @@
     <Reference Include="Assembly-CSharp">
       <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\SteamApps\common\Kerbal Space Program\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Assembly-CSharp-firstpass, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\SteamApps\common\Kerbal Space Program\KSP_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />


### PR DESCRIPTION
Saw these coming up in a game I was working on with someone who had issues with scenario module loading. Thought you might be able to use this simple fix - or it could point you to something else

Error Details:
NullReferenceException: Object reference not set to an instance of an object
at TarsierSpaceTech.TSTProgressTracker.OnLoad (.ConfigNode node) [0x00000] in <filename unknown>:0 
at ScenarioModule.Load (.ConfigNode node) [0x00000] in <filename unknown>:0 
at ScenarioRunner.AddModule (.ConfigNode node) [0x00000] in <filename unknown>:0 
at ProtoScenarioModule.Load (.ScenarioRunner host) [0x00000] in <filename unknown>:0 
at ScenarioRunner+.MoveNext () [0x00000] in <filename unknown>:0
